### PR TITLE
Add stylesLanguage as argument for reactFunctionComponentTemplate

### DIFF
--- a/src/generateComponent.ts
+++ b/src/generateComponent.ts
@@ -87,7 +87,7 @@ async function writeComponentFiles(directory: string, componentName: string) {
   const componentPath = `${directory}/${componentName}/${componentName}.${language}x`;
   const componentPromise = writeFile(
     componentPath,
-    reactFunctionComponentTemplate(componentName)
+    reactFunctionComponentTemplate(componentName, stylesLanguage)
   );
 
   // Write style file

--- a/src/templates/reactFunctionComponentTemplate.ts
+++ b/src/templates/reactFunctionComponentTemplate.ts
@@ -1,8 +1,13 @@
-export function reactFunctionComponentTemplate(componentName: string) {
+import { StyleLanguage } from '../types';
+
+export function reactFunctionComponentTemplate(
+  componentName: string,
+  stylesLanguage: StyleLanguage = StyleLanguage.scss
+) {
   return `
 import React from 'react';
 
-import styles from './${componentName}.scss';
+import styles from './${componentName}.${stylesLanguage}';
 
 export interface ${componentName}Props {
   prop?: string;


### PR DESCRIPTION
I was using this with a react app that uses `.module.scss`. When my react components were created, the import path to my style sheets were defaulted to `.scss`. I had to change the file path every time I created a new component. I have added `stylesLanguage` as an argument to `reactFunctionComponentTemplate` to ensure the `stylesLanguage` setting is used when creating the import path to stylesheets in the react component.