### PR TITLE
Prefer typing on variable to casting

### DIFF
--- a/src/templates/storiesTemplate.ts
+++ b/src/templates/storiesTemplate.ts
@@ -17,7 +17,7 @@ export function storiesTemplate(
 
   text =
     text +
-    `export default {\n` +
+    `const meta: Meta = {\n` +
     `  title: 'components/${componentName}',\n` +
     `  component: ${componentName},\n` +
     `  parameters: {\n`;
@@ -37,7 +37,7 @@ export function storiesTemplate(
     `      url: 'https://www.figma.com/file/...?node-id=...',\n` +
     `    },\n` +
     `  },\n` +
-    `} as Meta;\n\n`;
+    `};\n\n`;
 
   if (verboseComments) {
     text = text + `// 👇 We create a "template" of how args map to rendering\n`;
@@ -60,7 +60,10 @@ export function storiesTemplate(
       `// Learn more: https://storybook.js.org/docs/react/writing-stories/args\n`;
   }
 
-  text = text + `Basic.args = {};\n`;
+  text = 
+    text + 
+      `Basic.args = {};\n\n` +
+      `export default meta;\n`;
 
   return text;
 }


### PR DESCRIPTION
This PR updates the Storybook template to type `Meta` to a variable and export that variable as default. The previous implementation casted the `Meta` type on the anonymous default object, which didn't allow for type checking/intellisense against the expected params.