### PR TITLE
Update Storybook template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this extension will be documented in this file.
 
 -
 
+## [1.0.7] - 2022-09-29
+
+- Removes title from `Meta` object in stories template
+- Uses `import type` for imports from storybook in stories template
+
 ## [1.0.6] - 2022-02-22
 
 - Import StoryFn instead of Story type in storybook template

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "AndrewMcGoveran"
   },
-  "version": "1.0.6",
+  "version": "1.0.7",
   "engines": {
     "vscode": "^1.51.0"
   },

--- a/src/templates/storiesTemplate.ts
+++ b/src/templates/storiesTemplate.ts
@@ -4,7 +4,7 @@ export function storiesTemplate(
 ) {
   let text =
     `import React from 'react';\n` +
-    `import {Meta, StoryFn} from '@storybook/react';\n\n` +
+    `import type {Meta, StoryFn} from '@storybook/react';\n\n` +
     `import type {${componentName}Props} from './${componentName}';\n` +
     `import {${componentName}} from './${componentName}';\n\n`;
 
@@ -19,7 +19,6 @@ export function storiesTemplate(
   text =
     text +
     `const meta: Meta = {\n` +
-    `  title: 'components/${componentName}',\n` +
     `  component: ${componentName},\n` +
     `  parameters: {\n`;
 


### PR DESCRIPTION
- Removes title from `Meta` object
- Uses `import type` for imports from storybook